### PR TITLE
Restore autouse test DB access after sync_workflows removal; sync .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ splinter_tests.*/
 
 # Django stuff:
 staticfiles/
+static/
 
 # Sphinx documentation
 docs/_build/
@@ -324,6 +325,11 @@ tags
 ### VirtualEnv template
 # Virtualenv
 # http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ss]cripts
 pyvenv.cfg
 pip-selfcheck.json
 
@@ -350,7 +356,7 @@ topobank.db
 orcid.yaml
 
 # Locally generated pip packages
-docker/local/django/pip-packages/*
+compose/local/django/pip-packages/*
 
 # temporary files from soffice
 .~lock.*#
@@ -362,3 +368,19 @@ docker/local/django/pip-packages/*
 data/
 .envs/.local/.pypi-authfile
 
+# *.ttf and *.woff2 files
+static/js/*.ttf
+static/js/*.woff2
+
+# *.js files
+static/js/*.js
+
+.env
+
+# Shared project data paths (homogenized across ContactEngineering repos)
+data-lake
+topographies
+topobank/analysis/tests/topographies
+
+# Legacy docker-based generated pip packages
+docker/local/django/pip-packages/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,14 @@ from topobank.testing.factories import (OrganizationFactory, SurfaceFactory,
                                         TopographyAnalysisFactory, UserFactory)
 from topobank.testing.fixtures import handle_usage_statistics  # noqa: F401
 from topobank.testing.fixtures import simple_linear_2d_topography  # noqa: F401
-from topobank.testing.fixtures import sync_workflows  # noqa: F401
 from topobank.testing.fixtures import test_workflow  # noqa: F401
 from topobank.testing.fixtures import api_rf, two_topos  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def _enable_db_access_for_all_tests(db):
+    """Restore the implicit database access previously provided by the removed
+    autouse ``sync_workflows`` fixture in ``topobank.testing.fixtures``."""
 
 
 @pytest.fixture
@@ -61,7 +66,7 @@ def example_contact_analysis(test_workflow, user_with_plugin, settings):  # noqa
 
 
 @pytest.fixture
-def user_with_plugin(sync_workflows):  # noqa: F811
+def user_with_plugin(db):
     org_name = "Test Organization"
     org = OrganizationFactory(name=org_name)
     user = UserFactory()


### PR DESCRIPTION
topobank's testing fixtures dropped the autouse `sync_workflows` fixture that implicitly enabled DB access for every test, so the contact tests failed with "Database access not allowed". Add an autouse fixture depending on `db`, make `user_with_plugin` depend on `db` directly, and homogenize `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)