### PR TITLE
BUG: Stop calling removed Topography.get_absolute_url in periodicity alert

### DIFF
--- a/topobank_contact/workflows.py
+++ b/topobank_contact/workflows.py
@@ -320,8 +320,7 @@ class BoundaryElementMethod(WorkflowImplementation):
         # Check whether function is called with the right substrate_str and issue a warning if not
         alerts = []  # list of dicts with keys 'alert_class', 'message'
         if topography.is_periodic != (substrate_str == "periodic"):
-            alert_link = f'<a class="alert-link" href="{topography.get_absolute_url()}">{topography.name}</a>'
-            alert_message = f"Measurement {alert_link} is "
+            alert_message = f"Measurement {topography.name} is "
             if topography.is_periodic:
                 alert_message += (
                     "periodic, but the analysis is configured for free boundaries."


### PR DESCRIPTION
Fixes `AttributeError: 'Topography' object has no attribute 'get_absolute_url'`
in the contact-mechanics workflow.

`get_absolute_url()` was removed from the core Topography model in the
split-topobank refactor (core is now REST/UI-agnostic). The periodicity-mismatch
warning still built an `<a href="{topography.get_absolute_url()}">…</a>` link.
Render the measurement name as plain text instead — the analysis worker must not
reverse REST/UI routes, and the alert isn't delivered to the UI as a clickable
link anyway.

Depends on ContactEngineering/topobank#1361 (companion `make_alert_entry`
change; not strictly required here since this alert is built inline).

## Verification
With the `FakeTopographyModel.get_absolute_url` test stub removed in topobank,
the full suite passes: 11 passed (including
`test_alert_if_topographys_periodicity_does_not_match`, which exercises this
exact path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)