### PR TITLE
TST: Drop organizations URL include from test URLconf

### DIFF
--- a/test_urls.py
+++ b/test_urls.py
@@ -4,7 +4,6 @@ urlpatterns = [
     path("manager/", include("topobank_rest_api.manager.urls", namespace="manager")),
     path("analysis/", include("topobank_rest_api.analysis.urls", namespace="analysis")),
     path("users/", include("topobank_rest_api.users.urls", namespace="users")),
-    path("organizations/", include("topobank_rest_api.organizations.urls", namespace="organizations")),
     path("files/", include("topobank_rest_api.files.urls", namespace="files")),
     path("authorization/", include("topobank_rest_api.authorization.urls", namespace="authorization")),
     path("plugins/contact/", include("topobank_contact.urls", namespace="topobank_contact")),


### PR DESCRIPTION
topobank-rest-api removed its organizations app (organization management is gone from this stack), so this test URLconf can no longer include `topobank_rest_api.organizations.urls` — it now errors at test collection. Remove the include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)