### PR TITLE
ENH: Improve contact mechanics output accuracy and annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog for plugin *topobank-contact*
 
+## Unreleased
+
+- ENH: Contacting points and contact areas are now determined from the
+  optimizer's active set instead of thresholding forces (#16)
+- ENH: Per-step netCDF files now report the rigid body displacement
+  (offset) and the convergence status of each step (#28, #29)
+- ENH: Per-step netCDF files are now annotated with units (#24)
+- ENH: Analysis results now include the total forces, the scan area and
+  the rms height, enabling display of loads instead of nominal pressures
+  for nonperiodic calculations (#15, #25)
+- BUG: Raise a clear error for topographies with zero rms height instead
+  of producing NaN results
+
 ## 1.8.0 (2025-12-16)
 
 - UPSTREAM: Updated for API changes in topobank 1.66.0

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from SurfaceTopography import NonuniformLineScan as STNonuniformLineScan
+from SurfaceTopography import Topography as STTopography
 from topobank.testing.factories import ManifestSetFactory
 from topobank.testing.utils import (AnalysisResultMock, DummyProgressRecorder,
                                     FakeTopographyModel)
@@ -34,6 +35,80 @@ def test_contact_mechanics_whether_given_pressures_in_result(
     )
 
     np.testing.assert_almost_equal(result["mean_pressures"], given_pressures)
+
+
+def test_contact_mechanics_flat_topography_raises():
+    t = STTopography(np.zeros((16, 16)), physical_sizes=(1.0, 1.0), unit="nm")
+    topography = FakeTopographyModel(t)
+
+    with pytest.raises(IncompatibleTopographyException):
+        BoundaryElementMethod().topography_implementation(
+            AnalysisResultMock(topography, folder=ManifestSetFactory()),
+            progress_recorder=DummyProgressRecorder(),
+        )
+
+
+def test_contact_mechanics_step_file_annotations(simple_linear_2d_topography):
+    topography = FakeTopographyModel(simple_linear_2d_topography)
+    folder = ManifestSetFactory()
+    result = BoundaryElementMethod(
+        nsteps=None, pressures=[1e-2]
+    ).topography_implementation(
+        AnalysisResultMock(topography, folder=folder),
+        progress_recorder=DummyProgressRecorder(),
+    )
+
+    dataset = folder.read_xarray("step-0/nc/results.nc")
+
+    # Units are annotated on all variables and on the dataset (issue #24)
+    unit = simple_linear_2d_topography.unit
+    assert dataset.pressure.attrs["units"] == "E*"
+    assert dataset.gap.attrs["units"] == unit
+    assert dataset.displacement.attrs["units"] == unit
+    assert dataset.contacting_points.attrs["units"] == "1"
+    assert dataset.attrs["length_unit"] == unit
+
+    # The rigid body displacement (offset) and the convergence status are
+    # reported for each step (issues #28, #29). The result dict stores
+    # displacements normalized by the rms height.
+    assert dataset.attrs["mean_displacement"] == pytest.approx(
+        result["mean_displacements"][0] * result["rms_height"]
+    )
+    assert dataset.attrs["converged"] in (0, 1)
+    assert dataset.attrs["mean_pressure"] == pytest.approx(
+        result["mean_pressures"][0]
+    )
+
+    # The reported contact area is consistent with the contacting points map
+    # from the optimizer's active set (issue #16)
+    nb_pts = np.prod(dataset.contacting_points.shape)
+    assert dataset.attrs["total_contact_area"] == pytest.approx(
+        dataset.contacting_points.data.sum() / nb_pts
+    )
+
+
+def test_contact_mechanics_reports_forces_and_scan_area(
+    simple_linear_2d_topography,
+):
+    topography = FakeTopographyModel(simple_linear_2d_topography)
+    given_pressures = [2e-3, 1e-2]
+    result = BoundaryElementMethod(
+        nsteps=None, pressures=given_pressures
+    ).topography_implementation(
+        AnalysisResultMock(topography, folder=ManifestSetFactory()),
+        progress_recorder=DummyProgressRecorder(),
+    )
+
+    scan_area = np.prod(simple_linear_2d_topography.physical_sizes)
+    assert result["scan_area"] == pytest.approx(scan_area)
+    assert result["unit"] == simple_linear_2d_topography.unit
+    assert result["rms_height"] == pytest.approx(
+        simple_linear_2d_topography.rms_height_from_area()
+    )
+    # Total force is nominal pressure times scan area (issues #15, #25)
+    np.testing.assert_allclose(
+        result["mean_forces"], np.array(given_pressures) * scan_area
+    )
 
 
 @pytest.mark.parametrize(["x_dim", "y_dim"], [[20000, 10000], [9999999, 3]])

--- a/topobank_contact/workflows.py
+++ b/topobank_contact/workflows.py
@@ -39,6 +39,26 @@ class IncompatibleTopographyException(RuntimeError):
     pass
 
 
+def _extract_contacting_points(opt, force_xy):
+    """
+    Determine the map of contacting points from an optimization result.
+
+    The constrained optimizers report the set of points where the contact
+    constraint is active ('active_set'), which is more accurate than
+    thresholding the force field. The active set is reported on the
+    (possibly padded) computational domain and needs to be cropped to the
+    topography region, exactly like the displacement field `opt.x`. Fall
+    back to the force criterion if the solver does not report an active
+    set.
+    """
+    active_set = getattr(opt, "active_set", None)
+    if active_set is None:
+        return force_xy > 0
+    return np.asarray(
+        active_set[: force_xy.shape[0], : force_xy.shape[1]], dtype=bool
+    )
+
+
 def _next_contact_step(system, history=None, pentol=None, maxiter=None):
     """
     Run a full contact calculation. Try to guess displacement such that areas
@@ -130,6 +150,7 @@ def _next_contact_step(system, history=None, pentol=None, maxiter=None):
     )
     force_xy = opt.jac
     displacement_xy = opt.x[: force_xy.shape[0], : force_xy.shape[1]]
+    contacting_points_xy = _extract_contacting_points(opt, force_xy)
 
     # Use list append for efficiency, convert to arrays only when needed
     if isinstance(mean_displacements, list):
@@ -137,7 +158,9 @@ def _next_contact_step(system, history=None, pentol=None, maxiter=None):
         mean_gaps.append(np.mean(displacement_xy) - middle - mean_displacement)
         mean_load = force_xy.sum() / np.prod(topography.physical_sizes)
         mean_pressures.append(mean_load)
-        total_contact_area = (force_xy > 0).sum() / np.prod(topography.nb_grid_pts)
+        total_contact_area = contacting_points_xy.sum() / np.prod(
+            topography.nb_grid_pts
+        )
         total_contact_areas.append(total_contact_area)
         converged = np.append(converged, np.array([opt.success], dtype=bool))
     else:
@@ -147,7 +170,9 @@ def _next_contact_step(system, history=None, pentol=None, maxiter=None):
         )
         mean_load = force_xy.sum() / np.prod(topography.physical_sizes)
         mean_pressures = np.append(mean_pressures, [mean_load])
-        total_contact_area = (force_xy > 0).sum() / np.prod(topography.nb_grid_pts)
+        total_contact_area = contacting_points_xy.sum() / np.prod(
+            topography.nb_grid_pts
+        )
         total_contact_areas = np.append(total_contact_areas, [total_contact_area])
         converged = np.append(converged, np.array([opt.success], dtype=bool))
 
@@ -155,8 +180,6 @@ def _next_contact_step(system, history=None, pentol=None, maxiter=None):
     pressure_xy = force_xy / area_per_pt
     gap_xy = displacement_xy - topography.heights() - opt.offset
     gap_xy[gap_xy < 0.0] = 0.0
-
-    contacting_points_xy = force_xy > 0
 
     return (
         displacement_xy,
@@ -241,6 +264,7 @@ def _contact_at_given_load(
     )
     force_xy = opt.jac
     displacement_xy = opt.x[: force_xy.shape[0], : force_xy.shape[1]]
+    contacting_points_xy = _extract_contacting_points(opt, force_xy)
 
     # Use list append for efficiency, convert to arrays only when needed
     if isinstance(mean_displacements, list):
@@ -248,7 +272,9 @@ def _contact_at_given_load(
         mean_gaps.append(np.mean(displacement_xy) - middle - opt.offset)
         mean_load = force_xy.sum() / np.prod(topography.physical_sizes)
         mean_pressures.append(mean_load)
-        total_contact_area = (force_xy > 0).sum() / np.prod(topography.nb_grid_pts)
+        total_contact_area = contacting_points_xy.sum() / np.prod(
+            topography.nb_grid_pts
+        )
         total_contact_areas.append(total_contact_area)
         converged = np.append(converged, np.array([opt.success], dtype=bool))
     else:
@@ -256,7 +282,9 @@ def _contact_at_given_load(
         mean_gaps = np.append(mean_gaps, [np.mean(displacement_xy) - middle - opt.offset])
         mean_load = force_xy.sum() / np.prod(topography.physical_sizes)
         mean_pressures = np.append(mean_pressures, [mean_load])
-        total_contact_area = (force_xy > 0).sum() / np.prod(topography.nb_grid_pts)
+        total_contact_area = contacting_points_xy.sum() / np.prod(
+            topography.nb_grid_pts
+        )
         total_contact_areas = np.append(total_contact_areas, [total_contact_area])
         converged = np.append(converged, np.array([opt.success], dtype=bool))
 
@@ -264,8 +292,6 @@ def _contact_at_given_load(
     pressure_xy = force_xy / area_per_pt
     gap_xy = displacement_xy - topography.heights() - opt.offset
     gap_xy[gap_xy < 0.0] = 0.0
-
-    contacting_points_xy = force_xy > 0
 
     return (
         displacement_xy,
@@ -455,6 +481,11 @@ class BoundaryElementMethod(WorkflowImplementation):
         # This is necessary because numbers can vary greatly
         # depending on the system of units.
         rms_height = topography.rms_height_from_area()
+        if rms_height <= 0:
+            raise IncompatibleTopographyException(
+                "The rms height of this topography is zero; contact mechanics "
+                "of a perfectly flat surface is not supported."
+            )
         pentol = rms_height / (10 * np.mean(topography.nb_grid_pts))
         pentol = max(pentol, min_pentol)
 
@@ -507,9 +538,13 @@ class BoundaryElementMethod(WorkflowImplementation):
             pressure_xy = xr.DataArray(
                 pressure_xy, dims=("x", "y")
             )  # maybe define coordinates
+            pressure_xy.attrs["units"] = "E*"
             gap_xy = xr.DataArray(gap_xy, dims=("x", "y"))
+            gap_xy.attrs["units"] = topography.unit
             displacement_xy = xr.DataArray(displacement_xy, dims=("x", "y"))
+            displacement_xy.attrs["units"] = topography.unit
             contacting_points_xy = xr.DataArray(contacting_points_xy, dims=("x", "y"))
+            contacting_points_xy.attrs["units"] = "1"  # dimensionless contact mask
 
             # one dataset per analysis step: smallest unit to retrieve
             dataset = xr.Dataset(
@@ -520,8 +555,15 @@ class BoundaryElementMethod(WorkflowImplementation):
                     "displacement": displacement_xy,
                 }
             )
-            dataset.attrs["mean_pressure"] = mean_pressure
-            dataset.attrs["total_contact_area"] = total_contact_area
+            dataset.attrs["mean_pressure"] = mean_pressure  # units of E*
+            # Rigid body displacement (offset) of this step, in units of
+            # `length_unit`; negative values indicate deeper penetration
+            dataset.attrs["mean_displacement"] = mean_displacement
+            dataset.attrs["total_contact_area"] = total_contact_area  # fractional
+            # Whether the optimizer converged in this step; netCDF has no
+            # boolean attributes, hence stored as 0/1
+            dataset.attrs["converged"] = int(bool(history[4][-1]))
+            dataset.attrs["length_unit"] = topography.unit
             dataset.attrs["type"] = substrate_str
             if hardness:
                 dataset.attrs["hardness"] = (
@@ -662,14 +704,21 @@ class BoundaryElementMethod(WorkflowImplementation):
         return dict(
             name="topobank_contact.boundary_element_method",
             display_name="Contact mechanics",
+            unit=topography.unit,
+            rms_height=rms_height,
+            # Total scan area in units of `unit`²; the product of mean
+            # pressure and scan area is the total force in units of E*·`unit`²
+            scan_area=force_conv,
             area_per_pt=substrate.area_per_pt,
             maxiter=maxiter,
             min_pentol=min_pentol,
             mean_pressures=mean_pressure[sort_order],
+            # Total force in units of E*·`unit`²; this is the physically
+            # meaningful control quantity for nonperiodic (free boundary)
+            # calculations, where the nominal pressure F/A0 has no direct
+            # physical interpretation
+            mean_forces=mean_pressure[sort_order] * force_conv,
             total_contact_areas=total_contact_area[sort_order],
-            # TODO: divide-by-zero when rms_height == 0 (perfectly flat
-            # topography) yields inf/nan displacements and gaps; guard
-            # rms_height before dividing.
             mean_displacements=mean_displacement[sort_order] / rms_height,
             mean_gaps=mean_gap[sort_order] / rms_height,
             converged=converged[sort_order],


### PR DESCRIPTION
This PR implements the backend fixes for several long-standing issues, in two batches.

## Batch 1 — output annotations

- **Per-step netCDF files now carry units** (addresses #24): each variable (`pressure`, `gap`, `displacement`, `contacting_points`) gets a `units` attribute, and the dataset gets a `length_unit` attribute, making the files self-documenting regardless of the README.
- **The rigid body displacement (offset) is reported per step** (fixes #28): `mean_displacement` is now a dataset attribute of each `step-*/nc/results.nc`, so users no longer need to reconstruct it from the mean of the displacement field.
- **Per-step convergence status** is stored as a `converged` (0/1) attribute (addresses #29 together with the existing sort of `data_paths` by mean pressure — each step file is now self-identifying via its `mean_pressure`/`mean_displacement` attributes, so files can be ordered without cross-referencing the plot data).

## Batch 2 — correctness

- **Contacting points and contact areas are now determined from the optimizer's `active_set`** (fixes #16) instead of the `pressure > 0` criterion. The active set is reported by the constrained conjugate gradients solver on the (possibly padded) computational domain and is cropped to the topography region exactly like the displacement field. A fallback to the force criterion is kept for solvers that do not report an active set. This affects the reported total contact area, the contacting-points map, and the patch-size distribution.
- **Total forces are now part of the analysis result** (backend part of #15 / #25): the result dict gains `mean_forces` (units of E*·unit²), `scan_area`, `unit` and `rms_height`. This gives the frontend everything needed to plot load instead of nominal pressure for nonperiodic (free-boundary) calculations and to de-normalize displacements/gaps. Existing keys are unchanged, so the current frontend keeps working; a follow-up in ce-ui is needed to actually switch the axis for nonperiodic calculations.
- **Perfectly flat topographies now raise a clear `IncompatibleTopographyException`** instead of dividing by zero rms height and returning NaN/inf results.

## Tests

Three new tests: netCDF annotation round-trip (units, offset, convergence, active-set consistency), force/scan-area reporting, and the zero-rms-height guard. Full suite passes locally against PostgreSQL (14 passed), flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4nrhcuaPmP4asd5UuhCAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4nrhcuaPmP4asd5UuhCAr)_