### PR TITLE
DOC+ENH: Document conventions and add physical-unit rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- ENH: New optional workflow parameters `elastic_modulus` and
+  `elastic_modulus_unit` for rendering pressure axes of derived plots
+  (distributions, deep zoom images) in physical units (#26)
+- DOC: Added documentation of geometry and sign conventions, x/y
+  orientation, the definition of E* and load-controlled calculations,
+  including a kinematics figure and an example plot script
+  (#22, #27, #30)
+- DOC: Documented the composite-roughness recipe for the contact of two
+  rough surfaces (#17)
 - ENH: Contacting points and contact areas are now determined from the
   optimizer's active set instead of thresholding forces (#16)
 - ENH: Per-step netCDF files now report the rigid body displacement

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,16 @@ This plugin adds the following analysis function to Topobank:
 
 For more information, see our `paper`_.
 
+Documentation
+-------------
+
+- `Conventions <docs/conventions.md>`_ — geometry and sign conventions,
+  x/y orientation, definition of the contact modulus E*, units, and how
+  to treat the contact of two rough surfaces (composite roughness).
+- `Example script <docs/examples/plot_contact_step.py>`_ — reads a
+  ``results.nc`` file from the ZIP download and produces correctly
+  labeled plots.
+
 Installation
 ------------
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,139 @@
+# Conventions used in contact mechanics calculations
+
+This document describes the geometric conventions, sign conventions and
+units used by the *Contact mechanics* analysis of
+[contact.engineering](https://contact.engineering). All statements below
+refer to the quantities stored in the per-step netCDF files
+(`step-*/nc/results.nc`) contained in the ZIP download and to the values
+shown in the web app.
+
+![Kinematics of the contact problem](figures/kinematics.svg)
+
+## Heights
+
+- Uploaded topography data are **heights**, not gaps: peaks are positive
+  and point *out of* the material, towards the opposing body. If you
+  measured the gap of a rigid contact, you need to invert the sign before
+  uploading.
+- The analysis works with **detrended** data: the mean height is
+  subtracted before the calculation, i.e. the height profile *h* used
+  below fulfills mean(*h*) = 0. (Depending on the detrending mode chosen
+  for the measurement, a tilt may also have been removed.)
+
+## The contact problem
+
+The calculation solves frictionless, adhesionless normal contact of a
+rigid rough surface with height profile *h(x, y)* against a flat elastic
+half-space, using the boundary-element method with an FFT-based solver.
+Roughness on both bodies can be handled by mapping the problem onto the
+contact of a rigid rough body with the *composite* roughness against a
+flat elastic body with the *composite* elastic modulus (see below).
+
+The kinematic quantities are related by the gap equation
+
+    g(x, y) = u(x, y) − h(x, y) − d ≥ 0
+
+where
+
+- *g* is the local **gap** between the two surfaces (`gap` in the netCDF
+  files; negative values are clipped to zero),
+- *u* is the normal **displacement** of the elastic surface
+  (`displacement`),
+- *h* is the (detrended) height profile of the rigid surface, and
+- *d* is the **rigid body displacement** or *offset*
+  (`mean_displacement` attribute).
+
+## Sign of the rigid body displacement (offset)
+
+The offset *d* is a *penetration-like* coordinate, **not** a separation:
+
+- The surfaces touch first (at a single point, without deformation) when
+  *d* = −max(*h*).
+- **Increasing** *d* presses the bodies together and increases the
+  contact area; gaps are large when *d* is very negative.
+- Since mean(*h*) = 0, at *d* = 0 the rigid surface has (nominally)
+  penetrated the elastic body down to its mean plane.
+
+## In-plane coordinates: x and y
+
+- **x is the first array index, y is the second array index** of the
+  two-dimensional fields (`pressure`, `gap`, `displacement`,
+  `contacting_points`) stored in the netCDF files. This matches the
+  convention used for the topography data itself.
+- Grid spacing is `physical_sizes[0] / nb_grid_pts[0]` in x and
+  `physical_sizes[1] / nb_grid_pts[1]` in y.
+- In the color-map images rendered by the web app, the fields are
+  transposed for display: x runs horizontally (to the right) and y runs
+  vertically (image row convention).
+
+See [`examples/plot_contact_step.py`](examples/plot_contact_step.py) for
+a self-contained script that reads a `results.nc` file and produces
+correctly labeled plots.
+
+## Definition of the contact modulus E*
+
+All pressures are expressed in units of the **contact modulus**
+(also called effective or composite modulus)
+
+    1/E* = (1 − ν₁²)/E₁ + (1 − ν₂²)/E₂
+
+where *E*₁, *E*₂ are the Young's moduli and ν₁, ν₂ the Poisson numbers of
+the two contacting bodies. For a rigid indenter on an elastic body this
+reduces to 1/E* = (1 − ν²)/E. Because the contact problem is linear
+elastic and frictionless, the calculation itself is independent of the
+value of E*; results can be converted to physical units by multiplying
+with your value of E* (or by supplying `elastic_modulus` /
+`elastic_modulus_unit` when triggering the analysis, in which case
+pressure axes of the derived plots are rendered in physical units).
+
+## Load-controlled calculations
+
+When explicit pressure values are prescribed (`pressures` parameter), the
+imposed quantity is the **nominal pressure**
+
+    p = F / A₀
+
+where *F* is the total normal force and *A₀* is the (projected) scan
+area, i.e. the product of the physical sizes of the measurement. The
+solver then finds the offset *d* that produces this total force. When the
+number of steps (`nsteps`) is given instead, the calculation is
+displacement controlled and offsets are chosen such that the resulting
+contact areas are approximately equally spaced on a logarithmic scale.
+
+Note that for **nonperiodic** (free boundary) calculations the nominal
+pressure has no direct physical interpretation — the physically
+meaningful control quantity is the total force *F* = *p* · *A₀*, reported
+as `mean_forces` in the analysis result (in units of E*·unit²).
+
+## Units
+
+| Quantity | netCDF variable / attribute | Unit |
+|----------|-----------------------------|------|
+| Pressure field | `pressure` | E* |
+| Gap field | `gap` | length unit of the measurement (`length_unit` attribute) |
+| Displacement field | `displacement` | length unit of the measurement |
+| Contacting points | `contacting_points` | dimensionless mask (1 = in contact) |
+| Nominal pressure | `mean_pressure` attribute | E* |
+| Rigid body displacement | `mean_displacement` attribute | length unit of the measurement |
+| Contact area | `total_contact_area` attribute | fraction of the nominal (scan) area |
+| Total force | `mean_forces` (analysis result) | E* · (length unit)² |
+| Hardness | `hardness` attribute | E* |
+
+The contact area map and patch size distributions are computed from the
+active set of the constrained optimizer, i.e. the set of points where the
+non-penetration constraint is active.
+
+## Contact of two rough surfaces (composite roughness)
+
+To compute the contact of two rough surfaces *h*₁ and *h*₂ (both
+following the height convention above, peaks positive), run the
+calculation on the **composite roughness**
+
+    h = h₁ + h₂
+
+together with the composite modulus E* defined above. Adding the two
+height profiles (rather than subtracting) is correct because the peaks of
+both surfaces point towards the opposing body. At present you need to add
+the topographies yourself (e.g. in Python with
+[SurfaceTopography](https://github.com/ContactEngineering/SurfaceTopography))
+and upload the sum as a new measurement.

--- a/docs/examples/plot_contact_step.py
+++ b/docs/examples/plot_contact_step.py
@@ -1,0 +1,58 @@
+"""
+Plot the results of a single contact mechanics load step downloaded from
+contact.engineering.
+
+The ZIP download of a contact mechanics analysis contains one netCDF file
+per load step, named `step-<n>/nc/results.nc`. Each file holds the
+two-dimensional pressure, gap, displacement and contacting-points fields
+of that step; global scalars (nominal pressure, rigid body displacement,
+convergence status, units) are stored as attributes.
+
+Conventions (see docs/conventions.md for details):
+- x is the FIRST array index, y is the SECOND array index.
+- Pressures are in units of the contact modulus E*; lengths are in the
+  unit given by the `length_unit` attribute.
+- The rigid body displacement (`mean_displacement`) is a penetration-like
+  coordinate: increasing values press the surfaces together.
+
+Usage:
+    python plot_contact_step.py path/to/step-0/nc/results.nc
+"""
+
+import sys
+
+import matplotlib.pyplot as plt
+import xarray as xr
+
+filename = sys.argv[1] if len(sys.argv) > 1 else "results.nc"
+ds = xr.load_dataset(filename)
+
+unit = ds.attrs.get("length_unit", "?")
+print(f"Boundary conditions:      {ds.attrs['type']}")
+print(f"Nominal pressure:         {ds.attrs['mean_pressure']:.5g} E*")
+print(f"Fractional contact area:  {ds.attrs['total_contact_area']:.5g}")
+if "mean_displacement" in ds.attrs:
+    print(f"Rigid body displacement:  {ds.attrs['mean_displacement']:.5g} {unit}")
+if "converged" in ds.attrs:
+    print(f"Converged:                {bool(ds.attrs['converged'])}")
+
+fields = {
+    "pressure": f"Pressure ({ds.pressure.attrs.get('units', 'E*')})",
+    "gap": f"Gap ({ds.gap.attrs.get('units', unit)})",
+    "displacement": f"Displacement ({ds.displacement.attrs.get('units', unit)})",
+    "contacting_points": "Contacting points",
+}
+
+fig, axes = plt.subplots(2, 2, figsize=(10, 8))
+for ax, (name, label) in zip(axes.ravel(), fields.items()):
+    # The first array index is x, the second is y. matplotlib's imshow
+    # expects the leading index to be the image row (vertical), so we
+    # transpose and set origin="lower" to get x to the right and y up.
+    im = ax.imshow(ds[name].data.T, origin="lower", cmap="viridis")
+    ax.set_xlabel(f"x (pixels, spacing in {unit})")
+    ax.set_ylabel(f"y (pixels, spacing in {unit})")
+    ax.set_title(label)
+    fig.colorbar(im, ax=ax)
+
+fig.tight_layout()
+plt.show()

--- a/docs/figures/kinematics.svg
+++ b/docs/figures/kinematics.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="420" viewBox="0 0 720 420" font-family="Helvetica, Arial, sans-serif" font-size="15">
+  <!-- Background -->
+  <rect x="0" y="0" width="720" height="420" fill="white"/>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#444"/>
+    </marker>
+    <pattern id="hatch" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="8" stroke="#b0855a" stroke-width="1.5"/>
+    </pattern>
+    <pattern id="hatch-el" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="8" stroke="#7c9fc4" stroke-width="1.5"/>
+    </pattern>
+  </defs>
+
+  <!-- Elastic half-space (top). Its lower boundary is the deformed surface u(x). -->
+  <path d="M 40 40 L 680 40 L 680 122
+           C 640 122 620 132 590 138
+           C 560 144 545 118 520 112
+           C 495 106 480 128 450 136
+           C 420 144 400 146 370 142
+           C 340 138 330 112 305 108
+           C 280 104 265 132 235 140
+           C 205 148 175 146 145 140
+           C 115 134 95 124 40 122
+           Z"
+        fill="url(#hatch-el)" stroke="none" opacity="0.55"/>
+  <!-- Deformed elastic surface u(x) -->
+  <path d="M 680 122
+           C 640 122 620 132 590 138
+           C 560 144 545 118 520 112
+           C 495 106 480 128 450 136
+           C 420 144 400 146 370 142
+           C 340 138 330 112 305 108
+           C 280 104 265 132 235 140
+           C 205 148 175 146 145 140
+           C 115 134 95 124 40 122"
+        fill="none" stroke="#2b5c8a" stroke-width="2.5"/>
+  <text x="52" y="66" fill="#2b5c8a" font-weight="bold">elastic half-space</text>
+  <text x="52" y="86" fill="#2b5c8a">deformed surface at z = u(x)</text>
+
+  <!-- Undeformed elastic surface u = 0 (dashed) -->
+  <line x1="40" y1="150" x2="680" y2="150" stroke="#2b5c8a" stroke-width="1.5" stroke-dasharray="7 5"/>
+  <text x="420" y="168" fill="#2b5c8a">undeformed elastic surface (u = 0)</text>
+
+  <!-- Mean plane of the rigid surface z = d (dashed) -->
+  <line x1="40" y1="230" x2="680" y2="230" stroke="#8a5a2b" stroke-width="1.5" stroke-dasharray="7 5"/>
+  <text x="420" y="252" fill="#8a5a2b">mean plane of rigid surface (z = d)</text>
+
+  <!-- Rigid rough body (bottom), top boundary z = h(x) + d -->
+  <path d="M 40 250 L 75 262 L 105 238 L 145 205 L 175 252 L 205 270 L 235 236
+           L 265 210 L 305 108 L 330 226 L 370 258 L 400 240 L 450 218
+           L 480 262 L 520 112 L 545 232 L 590 246 L 620 224 L 655 258 L 680 244
+           L 680 385 L 40 385 Z"
+        fill="url(#hatch)" stroke="none" opacity="0.55"/>
+  <path d="M 40 250 L 75 262 L 105 238 L 145 205 L 175 252 L 205 270 L 235 236
+           L 265 210 L 305 108 L 330 226 L 370 258 L 400 240 L 450 218
+           L 480 262 L 520 112 L 545 232 L 590 246 L 620 224 L 655 258 L 680 244"
+        fill="none" stroke="#8a5a2b" stroke-width="2.5"/>
+  <text x="52" y="330" fill="#8a5a2b" font-weight="bold">rigid rough body</text>
+  <text x="52" y="350" fill="#8a5a2b">surface at z = h(x) + d,  mean(h) = 0</text>
+
+  <!-- Offset d: arrow from u=0 plane to rigid mean plane -->
+  <line x1="90" y1="150" x2="90" y2="230" stroke="#444" stroke-width="1.5" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+  <text x="98" y="196" fill="#444" font-style="italic">−d</text>
+
+  <!-- Height h(x): from mean plane up to a peak -->
+  <line x1="305" y1="230" x2="305" y2="112" stroke="#444" stroke-width="1.5" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+  <text x="313" y="180" fill="#444" font-style="italic">h(x)</text>
+
+  <!-- Gap g(x): between elastic surface and rigid surface in a non-contact region -->
+  <line x1="450" y1="136" x2="450" y2="218" stroke="#444" stroke-width="1.5" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+  <text x="458" y="182" fill="#444" font-style="italic">g(x) = u − h − d</text>
+
+  <!-- Contact points annotation -->
+  <circle cx="305" cy="108" r="5" fill="#c23b22"/>
+  <circle cx="520" cy="112" r="5" fill="#c23b22"/>
+  <text x="540" y="98" fill="#c23b22">contact: g = 0</text>
+
+  <!-- z axis -->
+  <line x1="660" y1="330" x2="660" y2="280" stroke="#444" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="668" y="300" fill="#444" font-style="italic">z</text>
+
+  <!-- Caption -->
+  <text x="40" y="408" fill="#444" font-size="13">Increasing the offset d presses the bodies together; first contact occurs at d = −max(h). Peaks are positive and point towards the opposing body.</text>
+</svg>

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pydantic
 import pytest
 from SurfaceTopography import NonuniformLineScan as STNonuniformLineScan
 from SurfaceTopography import Topography as STTopography
@@ -85,6 +86,45 @@ def test_contact_mechanics_step_file_annotations(simple_linear_2d_topography):
     assert dataset.attrs["total_contact_area"] == pytest.approx(
         dataset.contacting_points.data.sum() / nb_pts
     )
+
+
+def test_contact_mechanics_physical_units(simple_linear_2d_topography):
+    topography = FakeTopographyModel(simple_linear_2d_topography)
+    folder = ManifestSetFactory()
+    result = BoundaryElementMethod(
+        nsteps=None,
+        pressures=[1e-2],
+        elastic_modulus=250.0,
+        elastic_modulus_unit="GPa",
+    ).topography_implementation(
+        AnalysisResultMock(topography, folder=folder),
+        progress_recorder=DummyProgressRecorder(),
+    )
+
+    # The physical value of E* is passed through to the analysis result
+    # and the netCDF attributes (issue #26)
+    assert result["elastic_modulus"] == pytest.approx(250.0)
+    assert result["elastic_modulus_unit"] == "GPa"
+
+    dataset = folder.read_xarray("step-0/nc/results.nc")
+    assert dataset.attrs["elastic_modulus"] == pytest.approx(250.0)
+    assert dataset.attrs["elastic_modulus_unit"] == "GPa"
+    # The stored fields remain in units of E*
+    assert dataset.pressure.attrs["units"] == "E*"
+    assert dataset.attrs["mean_pressure"] == pytest.approx(1e-2)
+
+    # The pressure distribution is rendered in physical units
+    distributions = folder.read_json("step-0/json/distributions.json")
+    assert distributions["pressureUnit"] == "GPa"
+    assert distributions["pressureProbabilityDensityUnit"] == "GPa⁻¹"
+    # Pressures extend up to the order of the physical mean pressure,
+    # i.e. values are scaled by E*
+    assert max(distributions["pressure"]) > 1e-2 * 250.0
+
+
+def test_contact_mechanics_rejects_nonpositive_elastic_modulus():
+    with pytest.raises(pydantic.ValidationError):
+        BoundaryElementMethod(elastic_modulus=-1.0)
 
 
 def test_contact_mechanics_reports_forces_and_scan_area(

--- a/topobank_contact/workflows.py
+++ b/topobank_contact/workflows.py
@@ -328,6 +328,15 @@ class BoundaryElementMethod(WorkflowImplementation):
         pressures: Union[list[float], None] = None
         # Maximum number of iterations unless convergence
         maxiter: int = 100
+        # Contact modulus E* in physical units of pressure (given by
+        # elastic_modulus_unit); if provided, pressure axes of the derived
+        # plots (distributions, deep zoom images) are rendered in physical
+        # units. The calculation itself is carried out in units of E* and
+        # does not depend on this value; the fields stored in the netCDF
+        # files remain in units of E*.
+        elastic_modulus: Union[float, None] = None
+        # Unit of elastic_modulus
+        elastic_modulus_unit: str = "GPa"
 
         @field_validator("nsteps")
         @classmethod
@@ -338,6 +347,13 @@ class BoundaryElementMethod(WorkflowImplementation):
             # TypeError.
             if value is not None and value < 1:
                 raise ValueError("'nsteps' must be at least 1.")
+            return value
+
+        @field_validator("elastic_modulus")
+        @classmethod
+        def _validate_elastic_modulus(cls, value):
+            if value is not None and value <= 0:
+                raise ValueError("'elastic_modulus' must be positive.")
             return value
 
         @field_validator("pressures")
@@ -363,6 +379,18 @@ class BoundaryElementMethod(WorkflowImplementation):
         nsteps = self.kwargs.nsteps
         pressures = self.kwargs.pressures
         maxiter = self.kwargs.maxiter
+        elastic_modulus = self.kwargs.elastic_modulus
+        elastic_modulus_unit = self.kwargs.elastic_modulus_unit
+
+        # Pressures are computed in units of the contact modulus E*. If the
+        # user provided a value for E*, the derived plots (distributions,
+        # deep zoom images) are rendered in physical units instead.
+        if elastic_modulus is None:
+            pressure_fac = 1.0
+            pressure_unit = "E*"
+        else:
+            pressure_fac = elastic_modulus
+            pressure_unit = elastic_modulus_unit
 
         topography = analysis.subject
         folder = analysis.folder
@@ -564,6 +592,12 @@ class BoundaryElementMethod(WorkflowImplementation):
             # boolean attributes, hence stored as 0/1
             dataset.attrs["converged"] = int(bool(history[4][-1]))
             dataset.attrs["length_unit"] = topography.unit
+            if elastic_modulus is not None:
+                # Physical value of the contact modulus E*; multiply
+                # pressures (stored in units of E*) by this value to obtain
+                # physical pressures
+                dataset.attrs["elastic_modulus"] = elastic_modulus
+                dataset.attrs["elastic_modulus_unit"] = elastic_modulus_unit
             dataset.attrs["type"] = substrate_str
             if hardness:
                 dataset.attrs["hardness"] = (
@@ -585,14 +619,16 @@ class BoundaryElementMethod(WorkflowImplementation):
 
             fac = get_unit_conversion_factor(topography.unit, "m")
 
-            hist, edges = np.histogram(pressure_xy, density=True, bins=50)
+            hist, edges = np.histogram(
+                pressure_xy.data * pressure_fac, density=True, bins=50
+            )
             data_dict = {
                 "pressure": (edges[1:-1] + edges[2:]) / 2,
                 "pressureProbabilityDensity": hist[1:],
                 "pressureLabel": "Pressure p",
-                "pressureUnit": "E*",
+                "pressureUnit": pressure_unit,
                 "pressureProbabilityDensityLabel": "Probability density P(p)",
-                "pressureProbabilityDensityUnit": "E*⁻¹",
+                "pressureProbabilityDensityUnit": f"{pressure_unit}⁻¹",
             }
 
             hist, edges = np.histogram(gap_xy, density=True, bins=50)
@@ -647,12 +683,12 @@ class BoundaryElementMethod(WorkflowImplementation):
             #
 
             render_deepzoom(
-                pressure_xy.data,
+                pressure_xy.data * pressure_fac,
                 folder,
                 storage_prefix=f"{storage_path}/dzi/pressure",
                 physical_sizes=topography.physical_sizes,
                 unit=topography.unit,
-                colorbar_title="Pressure (E*)",
+                colorbar_title=f"Pressure ({pressure_unit})",
             )
             render_deepzoom(
                 contacting_points_xy.data.astype(int),
@@ -705,6 +741,10 @@ class BoundaryElementMethod(WorkflowImplementation):
             name="topobank_contact.boundary_element_method",
             display_name="Contact mechanics",
             unit=topography.unit,
+            # Physical value of the contact modulus E* (or None); multiply
+            # mean_pressures by this value to obtain physical pressures
+            elastic_modulus=elastic_modulus,
+            elastic_modulus_unit=elastic_modulus_unit,
             rms_height=rms_height,
             # Total scan area in units of `unit`²; the product of mean
             # pressure and scan area is the total force in units of E*·`unit`²


### PR DESCRIPTION
Follow-up to #51, implementing the documentation batch and the physical-units feature.

## Batch 3 — conventions documentation (closes #22, closes #27, closes #30)

New `docs/conventions.md`, linked from the README, covering:

- **Height/sign conventions**: heights (not gaps) are uploaded, peaks positive pointing out of the material; the analysis works with detrended data (mean subtracted).
- **The gap equation** `g = u − h − d` and the sign of the rigid body displacement: the offset is a *penetration-like* coordinate (first contact at `d = −max(h)`, gaps large at very negative `d`) — this settles the sign question discussed at length in #22.
- **x/y orientation** (#27): x is the first array index, y the second, in both topography and result fields; the color-map images transpose for display (x right, y in image-row direction). Verified against the DZI writer (`SurfaceTopography/IO/DZI.py` transposes via `subdata.T` before `Image.fromarray`).
- **Definition of E*** with formula, and clarification that load-controlled calculations impose the nominal pressure `F/A₀` — the two checklist items of #30.
- A **units table** for all netCDF variables and attributes.
- A new **kinematics figure** (`docs/figures/kinematics.svg`) illustrating the geometry; drawn from scratch, so no licensing concerns with the thesis figure from the #22 thread (which could still replace it if preferred).
- A **demo script** `docs/examples/plot_contact_step.py` that reads a `results.nc` from the ZIP download and produces correctly labeled plots — the concrete ask in both #22 and #27.

## Batch 4 — physical units (addresses #26); #23/#17 scoping

- **New optional workflow parameters `elastic_modulus` / `elastic_modulus_unit`** (default `None` / `"GPa"`): when the user supplies the physical value of E*, the pressure axes of the derived outputs — the pressure distribution JSON and the deep-zoom color bar — are rendered in physical units. The calculation is independent of E*, and the netCDF fields intentionally stay in nondimensional units of E* (annotated with `elastic_modulus`/`elastic_modulus_unit` attributes so they remain self-documenting). The analysis result passes the modulus through, so ce-ui can additionally offer the nondimensional/dimensional toggle suggested in #25 without recomputation. Validation rejects non-positive moduli.
- **#23** (single netCDF for all steps): not implemented here — per the discussion on the issue, per-step storage is intentional (lazy S3 loading) and the merge belongs in topobank core's download machinery. Left open.
- **#17** (contact of two uploaded surfaces): the full feature needs two-subject workflow support in topobank core. The documented composite-roughness recipe (`h = h₁ + h₂` with the composite modulus) in `docs/conventions.md` provides the interim workaround.

## Tests

Two new tests: physical-unit pass-through and scaling of the distribution JSON, and rejection of non-positive moduli. Full suite passes locally against PostgreSQL (16 passed), flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4nrhcuaPmP4asd5UuhCAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4nrhcuaPmP4asd5UuhCAr)_